### PR TITLE
enforce arrow parens at all times in order to not mess with flow types

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ module.exports = {
         'everything-else',
       ],
     }],
+    'arrow-parens': 'always',
     // don't use .jsx extensions
     'react/jsx-filename-extension': [1, { "extensions": [".js"] }],
     'flowtype/define-flow-type': 1,


### PR DESCRIPTION
I would like our rules to change to always require `arrow-parens`. If you use flow type annotations, you need to add the parens anyways, but the `--fix` option of `eslint` will remove the parens, if this option is not set. This will then result in non-working JS.
