### PR TITLE
linter error for unused vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,9 +23,6 @@ module.exports = {
     // better readability for nested function calls
     'space-in-parens': 0,
 
-    // to allow rest destructing with unused vars
-    'no-unused-vars': ['warn', { vars: 'local', args: 'after-used' }],
-
     // to allow defining internal helper functions after the exported objects
     'no-use-before-define': 0,
 


### PR DESCRIPTION
we had an override of the `no-unused-vars` rule is place to allow using the object destructing with spread syntax for omitting some properties of an object, e.g.: `const { foo, ...restWithoutFoo } = props`

After some discussions, @frontendphil and I figured it would be better to make the omitting explicit in such cases by using a descriptive function such as lodash's omit: `const restWithoutFoo = omit(props, 'foo')`. Otherwise, you simply wouldn't be able to tell whether `foo` was just omitted or whether it was actually meant to be used.