### PR TITLE
add `type-annotations` to react/sort-comp

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
             'warn',
             {
                 order: [
+                    'type-annotations',
                     'static-methods',
                     'lifecycle',
                     'render',


### PR DESCRIPTION
this allows us to set `props` and `state` type annotations at the top of a class definition which adds readability.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md