### PR TITLE
No trailing commas in lists of function arguments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -59,7 +59,7 @@ module.exports = {
                 tabWidth: 4,
                 semi: false,
                 singleQuote: true,
-                trailingComma: 'all',
+                trailingComma: 'es5',
             },
         ],
     },


### PR DESCRIPTION
these were not supported by node <8